### PR TITLE
Fix SvelteKit build for DigitalOcean deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "scripts": {
     "prebuild": "svelte-kit sync",
-    "build": "svelte-kit build",
+    "build": "vite build",
     "start": "node build",
     "dev": "vite dev --host",
     "preview": "vite preview --host",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
-	"compilerOptions": {
+        "extends": "./.svelte-kit/tsconfig.json",
+        "compilerOptions": {
 		"target": "ES2022",
 		"lib": ["ES2022", "DOM"],
 		"module": "ESNext",


### PR DESCRIPTION
## Summary
- ensure TypeScript config extends the generated SvelteKit settings
- switch build script to `vite build` so production builds succeed

## Testing
- `npm run build`
- `npm run lint` *(fails: Code style issues found in 177 files. Forgot to run Prettier?)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b752dbc28c83258c6ec2ee69272965