### PR TITLE
fix: handle empty Google Sheets properly in header initialization

### DIFF
--- a/src/lib/services/googleSheets.ts
+++ b/src/lib/services/googleSheets.ts
@@ -99,11 +99,15 @@ export async function initializeSheetHeaders(): Promise<void> {
     const doc = await getGoogleSheet();
     const sheet = doc.sheetsByIndex[0]; // Use first sheet
     
-    // Load the header row to check if headers exist
-    const rows = await sheet.getRows({ limit: 1 });
+    // Check if sheet has any data by looking at cell count
+    await sheet.loadCells('A1:K1'); // Load first row to check for headers
     
-    if (rows.length === 0) {
-      // If no rows exist, set the header row
+    // Check if the first row has any values
+    const hasHeaders = sheet.getCellByA1('A1').value !== null;
+    
+    if (!hasHeaders) {
+      // If no headers exist, set the header row
+      console.log('📝 Setting up headers for empty sheet...');
       await sheet.setHeaderRow([
         'Timestamp',
         'Primary Name',


### PR DESCRIPTION
- Replace getRows() with loadCells() to avoid header row dependency
- Check cell A1 for existing headers instead of trying to read rows
- This fixes the 'No values in the header row' error for empty sheets
- The code will now automatically set up headers when the sheet is empty