### PR TITLE
feat: implement RSVP submission tracking with cookies

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -1,14 +1,16 @@
 <script>
   import { page } from "$app/stores";
 
+  export let hasSubmittedRSVP = false;
+
   let innerWidth = 0;
   $: isMobile = innerWidth < 768;
 
-  const navItems = [
+  $: navItems = [
     { href: "/", label: "Home", icon: "🏠" },
     { href: "/story", label: "Our Story", icon: "💕" },
     { href: "/registry", label: "Registry", icon: "🎁" },
-    { href: "/rsvp", label: "RSVP", icon: "✉️" },
+    { href: "/rsvp", label: hasSubmittedRSVP ? "RSVP Info" : "RSVP", icon: hasSubmittedRSVP ? "📝" : "✉️" },
   ];
 
   $: currentPath = $page.url.pathname;

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,25 @@
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ cookies }) => {
+  const rsvpSubmission = cookies.get('rsvp-submitted');
+  
+  if (rsvpSubmission) {
+    try {
+      const submissionData = JSON.parse(rsvpSubmission);
+      return {
+        hasSubmittedRSVP: true,
+        rsvpSubmissionData: {
+          primaryName: submissionData.primaryName,
+          submittedAt: submissionData.submittedAt
+        }
+      };
+    } catch (error) {
+      // If cookie is corrupted, clear it
+      cookies.delete('rsvp-submitted');
+    }
+  }
+  
+  return {
+    hasSubmittedRSVP: false
+  };
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,8 @@
   import "../app.css";
   import Nav from "$lib/components/Nav.svelte";
 
+  export let data;
+
   let innerWidth = 0;
   $: isMobile = innerWidth < 768;
 </script>
@@ -9,7 +11,7 @@
 <svelte:window bind:innerWidth />
 
 <div class="min-h-screen flex flex-col">
-  <Nav />
+  <Nav hasSubmittedRSVP={data.hasSubmittedRSVP} />
 
   <main class="flex-1 {isMobile ? 'pb-20' : ''}">
     <slot />

--- a/src/routes/admin/clear-rsvp/+server.ts
+++ b/src/routes/admin/clear-rsvp/+server.ts
@@ -1,0 +1,10 @@
+import type { RequestHandler } from './$types';
+import { redirect } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ cookies }) => {
+  // Clear the RSVP cookie
+  cookies.delete('rsvp-submitted', { path: '/' });
+  
+  // Redirect back to RSVP page
+  throw redirect(302, '/rsvp');
+};

--- a/src/routes/rsvp/+page.svelte
+++ b/src/routes/rsvp/+page.svelte
@@ -4,6 +4,7 @@
   import { onMount } from "svelte";
 
   export let form;
+  export let data;
 
   let mounted = false;
   let attendeeNames = [""];
@@ -62,7 +63,62 @@
   </section>
 
   <div class="max-w-2xl mx-auto py-16 px-4 md:px-6">
-    {#if form?.success}
+    {#if data.hasSubmittedRSVP}
+      <!-- Already Submitted RSVP Information -->
+      <div class="text-center" in:fade={{ duration: 600 }}>
+        <div
+          class="bg-gradient-to-br from-coffee-50 to-cream-100 border-2 border-coffee-300 text-coffee-800 px-8 py-12 rounded-xl mb-8 shadow-lg"
+        >
+          <div class="text-6xl mb-6">📝</div>
+          <h2 class="text-3xl font-serif font-bold mb-6 text-coffee-800">RSVP Information</h2>
+          <p class="text-lg mb-6 leading-relaxed">
+            Hi {data.submissionData.primaryName}! We have your RSVP on file.
+          </p>
+          
+          <!-- RSVP Details Card -->
+          <div class="bg-white p-6 rounded-lg border border-coffee-200 mb-6 mx-auto max-w-md">
+            <h3 class="text-xl font-serif font-semibold text-coffee-800 mb-4">Your RSVP Details</h3>
+            <div class="text-coffee-700 space-y-2">
+              <p class="text-base">👥 <strong>{data.submissionData.attendanceCount} Guest{data.submissionData.attendanceCount > 1 ? 's' : ''}</strong></p>
+              <p class="text-sm">📅 Submitted: {new Date(data.submissionData.submittedAt).toLocaleDateString()}</p>
+            </div>
+          </div>
+          
+          <!-- Wedding Details Card -->
+          <div class="bg-white p-6 rounded-lg border border-coffee-200 mb-6 mx-auto max-w-md">
+            <h3 class="text-xl font-serif font-semibold text-coffee-800 mb-4">Wedding Details</h3>
+            <div class="text-coffee-700 space-y-2">
+              <p class="text-lg font-medium">📅 <strong>November 22nd, 2025</strong></p>
+              <p class="text-base">🕐 <strong>Arrive by 2:00 PM</strong></p>
+              <p class="text-base">💒 <strong>Ceremony starts at 2:30 PM</strong></p>
+            </div>
+          </div>
+          
+          <p class="text-sm text-coffee-600 mb-4">
+            Need to make changes to your RSVP? Please text Skyler at <strong>423-370-6198</strong>.
+          </p>
+          
+          <p class="text-coffee-700 font-medium">
+            We can't wait to celebrate with you! ☕💕
+          </p>
+        </div>
+
+        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+          <a
+            href="/story"
+            class="bg-coffee-700 text-cream-100 px-6 py-3 rounded-md hover:bg-coffee-800 transition-colors duration-300"
+          >
+            Read Our Story
+          </a>
+          <a
+            href="/registry"
+            class="bg-coffee-100 text-coffee-800 border-2 border-coffee-700 px-6 py-3 rounded-md hover:bg-coffee-200 transition-colors duration-300"
+          >
+            View Registry
+          </a>
+        </div>
+      </div>
+    {:else if form?.success}
       <!-- Success Message -->
       <div class="text-center" in:fade={{ duration: 600 }}>
         <div


### PR DESCRIPTION
- Add cookie-based system to track RSVP submissions
- Show 'RSVP Information' page for users who have already submitted
- Change navigation link from 'RSVP' to 'RSVP Info' after submission
- Display personalized RSVP details and wedding information
- Prevent duplicate submissions while allowing users to view their info
- Add admin route to clear RSVP cookie for testing (/admin/clear-rsvp)
- Use secure, httpOnly cookies that expire in 1 year
- Include layout server load function to check RSVP status globally